### PR TITLE
Use ArrayBuffers as argument from the start

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -20,14 +20,14 @@ export class Parser {
 	 */
 	public static ParseSave(
 		name: string,
-		bytes: Uint8Array,
+		bytes: ArrayBuffer,
 		options?: Partial<{
 			onDecompressedSaveBody: (buffer: ArrayBuffer) => void,
 			onProgressCallback: (progress: number, msg?: string) => void
 		}>
 	): SatisfactorySave {
 
-		const reader = new SaveReader(bytes.buffer, options?.onProgressCallback);
+		const reader = new SaveReader(bytes, options?.onProgressCallback);
 
 		const header = reader.readHeader();
 		const save = new SatisfactorySave(name, header);

--- a/src/parser/stream/reworked/readable-stream-parser.ts
+++ b/src/parser/stream/reworked/readable-stream-parser.ts
@@ -97,7 +97,7 @@ export class ReadableStreamParser {
 	 */
 	public static CreateReadableStreamFromSaveToJson = (
 		name: string,
-		bytes: Uint8Array,
+		bytes: ArrayBuffer,
 		options?: Partial<{
 			onDecompressedSaveBody: (buffer: ArrayBuffer) => void,
 			onProgress: (progress: number, message?: string) => void
@@ -137,7 +137,7 @@ export class ReadableStreamParser {
 
 		const startStreaming = async (): Promise<void> => {
 
-			const reader = new SaveReader(bytes.buffer, options?.onProgress);
+			const reader = new SaveReader(bytes, options?.onProgress);
 
 			// read header
 			const header = reader.readHeader();


### PR DESCRIPTION
Makes feeding data to the parser a little smoother when using `fetch()` as opposed to `fs.readfile()`.

Sample usage:

```typescript
const localArrayBuffer = (await readFile('foo.sav')).buffer
const localSave = Parser.ParseSave('FirstSave', arrayBuffer)

const fetchedArrayBuffer = await fetch('https://example.com/foo.sav').then(res =>res.arrayBuffer())
const fetchedSave = Parser.ParseSave('FirstSave', arrayBuffer)
```