### PR TITLE
fix: dont parse unknown data when end of buffer has been reached

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -65,11 +65,13 @@ export class Parser {
 		save.levels = reader.readLevels();
 
 		// unresolved data, probably not even useful.
-		const countUnresolvedWorldSaveData = reader.readInt32();
-		if (countUnresolvedWorldSaveData) {
-			save.unresolvedWorldSaveData = [];
-			for (let i = 0; i < countUnresolvedWorldSaveData; i++) {
-				save.unresolvedWorldSaveData.push(ObjectReference.read(reader));
+		if (reader.getBufferPosition() < reader.getBufferLength()) {
+			const countUnresolvedWorldSaveData = reader.readInt32();
+			if (countUnresolvedWorldSaveData) {
+				save.unresolvedWorldSaveData = [];
+				for (let i = 0; i < countUnresolvedWorldSaveData; i++) {
+					save.unresolvedWorldSaveData.push(ObjectReference.read(reader));
+				}
 			}
 		}
 

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -115,8 +115,8 @@ export class Parser {
 		// unresolved data
 		// TODO: check if we ever encounter it.
 		if (save.unresolvedWorldSaveData && save.unresolvedWorldSaveData.length > 0) {
-			writer.writeInt32(save.unresolvedWorldSaveData?.length ?? 0);
-			for (const actor of save.unresolvedWorldSaveData ?? []) {
+			writer.writeInt32(save.unresolvedWorldSaveData.length);
+			for (const actor of save.unresolvedWorldSaveData) {
 				ObjectReference.write(writer, actor);
 			}
 		}

--- a/src/parser/stream/reworked/readable-stream-parser.ts
+++ b/src/parser/stream/reworked/readable-stream-parser.ts
@@ -174,13 +174,15 @@ export class ReadableStreamParser {
 			await write(`}`, false);
 
 			// unresolved data
-			const countUnresolvedWorldSaveData = reader.readInt32();
-			if (countUnresolvedWorldSaveData) {
-				save.unresolvedWorldSaveData = [];
-				for (let i = 0; i < countUnresolvedWorldSaveData; i++) {
-					save.unresolvedWorldSaveData.push(ObjectReference.read(reader));
+			if (reader.getBufferPosition() < reader.getBufferLength()) {
+				const countUnresolvedWorldSaveData = reader.readInt32();
+				if (countUnresolvedWorldSaveData) {
+					save.unresolvedWorldSaveData = [];
+					for (let i = 0; i < countUnresolvedWorldSaveData; i++) {
+						save.unresolvedWorldSaveData.push(ObjectReference.read(reader));
+					}
+					await write(`, "unresolvedWorldSaveData": ${JSON.stringify(save.unresolvedWorldSaveData)} `, false);
 				}
-				await write(`, "unresolvedWorldSaveData": ${JSON.stringify(save.unresolvedWorldSaveData)} `, false);
 			}
 
 			if (save.name !== undefined) {


### PR DESCRIPTION
This PR adds a check on the remaining buffer before attempting to read beyond the levels.

I ran into an issue on a save file which appears to have no data for the `countUnresolvedWorldSaveData` int32.

```
RangeError: Offset is outside the bounds of the DataView
    at DataView.getInt32 (<anonymous>)
    at SaveReader.readInt32 (/@sleavely/satisfactory-savegame-prometheus-exporter/node_modules/@etothepii/satisfactory-file-parser/src/parser/byte/byte-reader.class.ts:72:30)
    at Function.ParseSave (/@sleavely/satisfactory-savegame-prometheus-exporter/node_modules/@etothepii/satisfactory-file-parser/src/parser/parser.ts:74:4)
    at extractMetrics (/@sleavely/satisfactory-savegame-prometheus-exporter/src/extractMetrics.ts:27:23)
    at async <anonymous> (/@sleavely/satisfactory-savegame-prometheus-exporter/bin/cli.ts:18:27)
```

I'm attaching the zipped savegame file if you want to analyze it further, but it's essentially a fresh singleplayer game from 1.0: [Onboarding_110225-081945.zip](https://github.com/user-attachments/files/24807919/Onboarding_110225-081945.zip)